### PR TITLE
Correct default password for the mirth client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use your preferred MySQL client connected to *localhost* port *3306*
 ## Connect to Mirth-Connect
 
 Double-click on *./webstart.jnlp* to start the Mirth-Connect client
-(user: *admin* / password: *password* )
+(user: *admin* / password: *admin* )
 
 or
 


### PR DESCRIPTION
Per the original docker image https://hub.docker.com/r/brandonstevens/mirth-connect/, the credentials to connect to the server was incorrect. Updated the README with the correct password